### PR TITLE
Fix file info path during edit when not multiple

### DIFF
--- a/lib/modules/generateFieldSchemaBase.js
+++ b/lib/modules/generateFieldSchemaBase.js
@@ -67,7 +67,7 @@ export default (options = {}) => {
           previewFromValue: once(() => (value, index, props) => {
             if (isString(resolveId(value))) {
               const resolvedValuePath = [resolverName];
-              if (isFinite(index)) {
+              if (multiple && isFinite(index)) {
                 resolvedValuePath.push(index);
               }
               return get(props.document, resolvedValuePath);


### PR DESCRIPTION
Hi,

I figured out a first bug: when previewing a single file, it still try to find the url at `['yourResolverName', 0]` as a default, even if your value is not an array.
Checking if the input allow multiple files seems to fix this.

Also, I have tried to write my own `previewFromValue` and add it in the schema, as you do here: https://github.com/OrigenStudio/vulcan-files-simple-example/blob/master/packages/example-instagram/lib/modules/pics/schema.js#L56

However, `value` is equal to the input props (and props is not defined). I could not trace where the call is made even when searching all references to this method, which sounds weird.