### PR TITLE
[WIP] Update to Apollo 2

### DIFF
--- a/lib/client/interface.js
+++ b/lib/client/interface.js
@@ -68,6 +68,7 @@ function serializeFormData(obj, formDataObj = {}, namespace) {
   return formDataObj;
 }
 
+// DEPRECATED with apollo 2
 export const fileUploadMiddleware = {
   applyMiddleware({ request, options }, next) {
     if (isUpload(request)) {

--- a/lib/client/main.js
+++ b/lib/client/main.js
@@ -1,12 +1,10 @@
-import { withRenderContext } from 'meteor/vulcan:lib';
-import { fileUploadMiddleware } from './interface';
+import { registerTerminatingLink } from 'meteor/vulcan:lib';
+import { createUploadLink } from 'apollo-upload-client';
+
+registerTerminatingLink(createUploadLink())
+
 
 export * from '../modules';
 export { default as generateFieldSchema } from '../modules/generateFieldSchemaBase';
 export { default as createFSCollection } from './createFSCollectionStub';
 
-Meteor.startup(() => {
-  withRenderContext(renderContext => {
-    renderContext.apolloClient.networkInterface.use([fileUploadMiddleware]);
-  });
-});

--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -1,3 +1,4 @@
+console.log("HERE")
 import './uploadMiddleware';
 import './addGraphQLSchemaAndResolvers';
 

--- a/lib/server/uploadMiddleware.js
+++ b/lib/server/uploadMiddleware.js
@@ -1,4 +1,4 @@
-import { webAppConnectHandlersUse } from 'meteor/vulcan:lib';
+import { addCallback } from 'meteor/vulcan:core';
 import objectPath from 'object-path';
 import brackets2Dots from 'brackets2dots';
 import asyncBusboy from 'async-busboy';
@@ -11,10 +11,13 @@ function isUpload(req) {
 
 async function graphqlUploadMiddleware(req, res, next) {
   try {
+    console.log("run middleware")
     if (!isUpload(req)) {
       return next();
     }
+    console.log("isUpload")
     const { files, fields } = await asyncBusboy(req);
+    console.log("files", files, fields)
 
     // console.log('');
     // console.log('## graphqlUploadMiddleware ##########################################');
@@ -33,8 +36,6 @@ async function graphqlUploadMiddleware(req, res, next) {
   return next();
 }
 
-Meteor.startup(() => {
-  webAppConnectHandlersUse('graphql-upload-middleware', '/graphql', graphqlUploadMiddleware, {
-    order: 1
-  });
-});
+addCallback('graphql.middlewares.setup', (WebApp) => {
+  WebApp.connectHandlers.use('/graphql', graphqlUploadMiddleware);
+})

--- a/lib/server/uploadMiddleware.js
+++ b/lib/server/uploadMiddleware.js
@@ -11,13 +11,10 @@ function isUpload(req) {
 
 async function graphqlUploadMiddleware(req, res, next) {
   try {
-    console.log("run middleware")
     if (!isUpload(req)) {
       return next();
     }
-    console.log("isUpload")
     const { files, fields } = await asyncBusboy(req);
-    console.log("files", files, fields)
 
     // console.log('');
     // console.log('## graphqlUploadMiddleware ##########################################');
@@ -36,6 +33,6 @@ async function graphqlUploadMiddleware(req, res, next) {
   return next();
 }
 
-addCallback('graphql.middlewares.setup', (WebApp) => {
+addCallback('graphql.middlewares.setup', function useGqlUploadMiddleware(WebApp) {
   WebApp.connectHandlers.use('/graphql', graphqlUploadMiddleware);
 })


### PR DESCRIPTION
We can't add middleware as we used to in the client. `apollo-link-fetch` does not accept much changes on the body so we can't simply update the middleware to become a link, we need a full fledged link that trigger the fetch itself.

Easiest way is to use [apollo-update-client](https://github.com/jaydenseric/apollo-upload-client) currently

Still on progress because it breaks the backend.

@see https://github.com/apollographql/apollo-link/issues/1111